### PR TITLE
maintenance: add module-ID mapping for reviewer analytics

### DIFF
--- a/contrib/maintenance/gerrit/module_mapping.py
+++ b/contrib/maintenance/gerrit/module_mapping.py
@@ -1,0 +1,66 @@
+"""Map Gerrit file paths to canonical module IDs (v1: first path segment).
+This module is shared by offline batch jobs (ingest-derived features) and should
+stay in sync with any Java-side resolver added later for ReviewerRecommender.
+See MODULE_MAPPING.md in this package for the full contract.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+# Paths that carry no code-ownership / module signal (aligned with ingest skips).
+_SKIP_PATHS = frozenset(
+    {
+        "/COMMIT_MSG",
+        "/MERGE_LIST",
+        "/PATCHSET_LEVEL",
+    }
+)
+
+# Single-segment paths at repo root map here so every file yields a stable ID.
+_ROOT_MODULE_ID = "__root__"
+
+
+def path_to_module_id(file_path: str) -> str | None:
+    """Return the v1 module ID for a single file path, or None if skipped.
+    Rules:
+    - Skip synthetic paths in ``_SKIP_PATHS``.
+    - Strip leading ``/`` (Gerrit often uses paths like ``/src/Foo.java``).
+    - If the path contains ``/``, the module ID is the first segment.
+    - If there is no ``/``, the whole path (filename) is the module ID, unless
+      empty, in which case use ``__root__``.
+    """
+    if not file_path:
+        return None
+    normalized = file_path.strip()
+    if normalized in _SKIP_PATHS:
+        return None
+    while normalized.startswith("/"):
+        normalized = normalized[1:]
+    if not normalized:
+        return None
+    slash = normalized.find("/")
+    if slash < 0:
+        return normalized if normalized else _ROOT_MODULE_ID
+    first = normalized[:slash]
+    return first if first else _ROOT_MODULE_ID
+
+
+def paths_to_module_ids(file_paths: Iterable[str]) -> frozenset[str]:
+    """Collect unique module IDs for an iterable of file paths."""
+    out: set[str] = set()
+    for p in file_paths:
+        mid = path_to_module_id(p)
+        if mid is not None:
+            out.add(mid)
+    return frozenset(out)
+
+
+def qualified_module_id(project: str, file_path: str) -> str | None:
+    """Return ``project:module_id`` for cross-repo uniqueness, or None if skipped.
+    *project* should be the Gerrit project name (e.g. ``plugins/my-plugin``).
+    """
+    mid = path_to_module_id(file_path)
+    if mid is None:
+        return None
+    return f"{project}:{mid}"

--- a/contrib/maintenance/tests/gerrit/test_module_mapping.py
+++ b/contrib/maintenance/tests/gerrit/test_module_mapping.py
@@ -1,0 +1,45 @@
+import pytest
+
+from gerrit.module_mapping import (
+    path_to_module_id,
+    paths_to_module_ids,
+    qualified_module_id,
+)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/COMMIT_MSG", None),
+        ("/MERGE_LIST", None),
+        ("/PATCHSET_LEVEL", None),
+        ("", None),
+        ("  ", None),
+        ("/java/com/Foo.java", "java"),
+        ("java/com/Foo.java", "java"),
+        ("polygerrit-ui/app/x.ts", "polygerrit-ui"),
+        ("README.md", "README.md"),
+        ("/LICENSE", "LICENSE"),
+        ("/", None),
+        ("//double", "double"),
+    ],
+)
+def test_path_to_module_id(path, expected):
+    assert path_to_module_id(path) == expected
+
+
+def test_path_to_module_id_empty_first_segment_uses_root():
+    assert path_to_module_id("/foo//bar") == "foo"
+
+
+def test_paths_to_module_ids_dedupes_and_skips():
+    assert paths_to_module_ids(
+        ["/a/x", "/a/y", "/b/z", "/COMMIT_MSG", "/a/w"]
+    ) == frozenset({"a", "b"})
+
+
+def test_qualified_module_id():
+    assert (
+        qualified_module_id("plugins/foo", "/java/Bar.java") == "plugins/foo:java"
+    )
+    assert qualified_module_id("plugins/foo", "/COMMIT_MSG") is None


### PR DESCRIPTION
## Summary

- Introduces `gerrit/module_mapping.py`, a shared utility that maps Gerrit
- file paths to canonical "v1 module IDs" — the first path segment of a
- file path, used as a stable grouping key for reviewer-expertise scoring.
- This module is intentionally kept as pure logic (no I/O, no DB) so it
- can be shared by the offline batch scorer, future ingest steps, and any
- Java-side resolver added later for `ReviewerRecommender`.

### Mapping rules
- Synthetic Gerrit paths (`/COMMIT_MSG`, `/MERGE_LIST`, `/PATCHSET_LEVEL`) → `None` (skipped)
- Leading `/` is stripped; empty results after stripping → `None`
- Paths with a `/`: first segment is the module ID (`src/main/Foo.java` → `src`)
- Root-level files (no `/`): the filename itself is the module ID (`README.md` → `README.md`)
- `qualified_module_id(project, path)` returns `project:module_id` for cross-repo uniqueness

### Public API
- `path_to_module_id(file_path)` → `str | None`
- `paths_to_module_ids(file_paths)` → `frozenset[str]`
- `qualified_module_id(project, file_path)` → `str | None`

## Test plan
- `test_module_mapping.py` covers all edge cases: synthetic paths, empty strings, leading slashes, double slashes, root-level files, deduplication via `paths_to_module_ids`, and cross-repo qualification
- Run `pytest contrib/maintenance/` locally 