### PR TITLE
maintenance: add SQLite schema and store methods for reviewer module scores

### DIFF
--- a/contrib/maintenance/gerrit/db.py
+++ b/contrib/maintenance/gerrit/db.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import Optional
+from typing import Collection, Dict, Optional
 
 from gerrit.models import (
     ChangeRecord,
@@ -8,6 +8,8 @@ from gerrit.models import (
     FileRecord,
     LabelVoteRecord,
     ReviewerRecord,
+    ModuleEdgeRecord,
+    ReviewerModuleScoreRecord,
 )
 
 _SCHEMA = """
@@ -79,6 +81,27 @@ CREATE INDEX IF NOT EXISTS idx_reviewers_account  ON reviewers(account_id);
 CREATE INDEX IF NOT EXISTS idx_votes_account      ON label_votes(account_id);
 CREATE INDEX IF NOT EXISTS idx_commits_repo       ON commits(repo);
 CREATE INDEX IF NOT EXISTS idx_commit_files_repo  ON commit_files(repo);
+
+CREATE TABLE IF NOT EXISTS module_edges (
+    project     TEXT    NOT NULL,
+    from_module TEXT    NOT NULL,
+    to_module   TEXT    NOT NULL,
+    PRIMARY KEY (project, from_module, to_module)
+);
+CREATE TABLE IF NOT EXISTS reviewer_module_scores (
+    project     TEXT    NOT NULL,
+    account_id  INTEGER NOT NULL,
+    module_id   TEXT    NOT NULL,
+    score       REAL    NOT NULL,
+    updated     TEXT,
+    PRIMARY KEY (project, account_id, module_id)
+);
+CREATE INDEX IF NOT EXISTS idx_module_edges_project
+    ON module_edges(project);
+CREATE INDEX IF NOT EXISTS idx_reviewer_scores_project_module
+    ON reviewer_module_scores(project, module_id);
+CREATE INDEX IF NOT EXISTS idx_reviewer_scores_account
+    ON reviewer_module_scores(account_id);
 """
 
 
@@ -196,6 +219,53 @@ class ReviewActivityStore:
     def commit(self) -> None:
         assert self._conn is not None
         self._conn.commit()
+
+    def upsert_module_edge(self, r: ModuleEdgeRecord) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """INSERT OR REPLACE INTO module_edges
+               (project, from_module, to_module)
+               VALUES (?, ?, ?)""",
+            (r.project, r.from_module, r.to_module),
+        )
+
+    def delete_module_edges_for_project(self, project: str) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            "DELETE FROM module_edges WHERE project = ?", (project,)
+        )
+
+    def upsert_reviewer_module_score(self, r: ReviewerModuleScoreRecord) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """INSERT OR REPLACE INTO reviewer_module_scores
+               (project, account_id, module_id, score, updated)
+               VALUES (?, ?, ?, ?, ?)""",
+            (r.project, r.account_id, r.module_id, r.score, r.updated),
+        )
+
+    def delete_reviewer_module_scores_for_project(self, project: str) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            "DELETE FROM reviewer_module_scores WHERE project = ?", (project,)
+        )
+
+    def sum_reviewer_scores_for_modules(
+        self, project: str, module_ids: Collection[str]
+    ) -> Dict[int, float]:
+        """Sum precomputed scores per account for the given v1 module IDs."""
+        assert self._conn is not None
+        if not module_ids:
+            return {}
+        placeholders = ",".join("?" * len(module_ids))
+        sql = (
+            f"SELECT account_id, SUM(score) AS total "
+            f"FROM reviewer_module_scores "
+            f"WHERE project = ? AND module_id IN ({placeholders}) "
+            f"GROUP BY account_id"
+        )
+        rows = self._conn.execute(sql, (project, *module_ids)).fetchall()
+        return {int(row["account_id"]): float(row["total"]) for row in rows}
 
 
     def latest_change_updated(self, project: str) -> Optional[str]:

--- a/contrib/maintenance/gerrit/models.py
+++ b/contrib/maintenance/gerrit/models.py
@@ -62,3 +62,25 @@ class CommitFileRecord:
     repo: str
     file_path: str
     change_type: str  # A=added, M=modified, D=deleted, R=renamed
+
+
+
+
+@dataclass
+class ModuleEdgeRecord:
+    """Directed dependency between v1 module IDs within one Gerrit project."""
+
+    project: str
+    from_module: str
+    to_module: str
+
+
+@dataclass
+class ReviewerModuleScoreRecord:
+    """Precomputed reviewer expertise for a module (batch job output)."""
+
+    project: str
+    account_id: int
+    module_id: str
+    score: float
+    updated: Optional[str] = None

--- a/contrib/maintenance/tests/gerrit/test_db.py
+++ b/contrib/maintenance/tests/gerrit/test_db.py
@@ -340,3 +340,85 @@ def test_latest_change_updated_ignores_other_projects(store):
     store.commit()
 
     assert store.latest_change_updated("proj-b") is None
+
+
+
+# ---------------------------------------------------------------------------
+# Module edges and reviewer_module_scores
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_module_edge(store):
+    from gerrit.models import ModuleEdgeRecord
+
+    store.upsert_module_edge(
+        ModuleEdgeRecord(project="p", from_module="a", to_module="b")
+    )
+    store.commit()
+    row = store._conn.execute(
+        "SELECT * FROM module_edges WHERE project = 'p'"
+    ).fetchone()
+    assert row["from_module"] == "a"
+    assert row["to_module"] == "b"
+
+
+def test_delete_module_edges_for_project(store):
+    from gerrit.models import ModuleEdgeRecord
+
+    store.upsert_module_edge(
+        ModuleEdgeRecord(project="p", from_module="x", to_module="y")
+    )
+    store.delete_module_edges_for_project("p")
+    store.commit()
+    n = store._conn.execute("SELECT COUNT(*) FROM module_edges").fetchone()[0]
+    assert n == 0
+
+
+def test_reviewer_module_scores_sum(store):
+    from gerrit.models import ReviewerModuleScoreRecord
+
+    store.upsert_reviewer_module_score(
+        ReviewerModuleScoreRecord(
+            project="gerrit", account_id=1, module_id="java", score=2.0, updated="t1"
+        )
+    )
+    store.upsert_reviewer_module_score(
+        ReviewerModuleScoreRecord(
+            project="gerrit", account_id=1, module_id="java", score=1.0, updated="t2"
+        )
+    )
+    store.upsert_reviewer_module_score(
+        ReviewerModuleScoreRecord(
+            project="gerrit", account_id=1, module_id="polygerrit-ui", score=5.0
+        )
+    )
+    store.upsert_reviewer_module_score(
+        ReviewerModuleScoreRecord(
+            project="gerrit", account_id=2, module_id="java", score=10.0
+        )
+    )
+    store.commit()
+
+    s = store.sum_reviewer_scores_for_modules("gerrit", ["java", "polygerrit-ui"])
+    assert s[1] == pytest.approx(6.0)
+    assert s[2] == pytest.approx(10.0)
+
+
+def test_sum_reviewer_scores_empty_modules(store):
+    assert store.sum_reviewer_scores_for_modules("p", []) == {}
+
+
+def test_delete_reviewer_module_scores_for_project(store):
+    from gerrit.models import ReviewerModuleScoreRecord
+
+    store.upsert_reviewer_module_score(
+        ReviewerModuleScoreRecord(
+            project="p", account_id=1, module_id="m", score=1.0
+        )
+    )
+    store.delete_reviewer_module_scores_for_project("p")
+    store.commit()
+    n = store._conn.execute(
+        "SELECT COUNT(*) FROM reviewer_module_scores"
+    ).fetchone()[0]
+    assert n == 0


### PR DESCRIPTION
## Summary

- Adds two new tables to `ReviewActivityStore` and the corresponding dataclasses and CRUD methods needed to persist precomputed reviewer-expertise scores, keyed by project and v1 module ID.
-  This is the storage layer for the upcoming batch scorer job. It has no effect on the existing ingest pipeline.

### New tables
- **`module_edges`** — directed dependency graph between v1 module IDs
  within a project `(project, from_module, to_module)`, for future
  graph-based scoring signals.
- **`reviewer_module_scores`** — precomputed expertise score per
  `(project, account_id, module_id)`, written by the batch scorer and
  read back at reviewer-suggestion time.

### New `ReviewActivityStore` methods
- `upsert_module_edge(r)` / `delete_module_edges_for_project(project)`
- `upsert_reviewer_module_score(r)` / `delete_reviewer_module_scores_for_project(project)`
- `sum_reviewer_scores_for_modules(project, module_ids)` — the hot-path
  read query: returns `{account_id: total_score}` across all supplied
  module IDs in a single `GROUP BY` SQL statement.

### New dataclasses (`models.py`)
- `ModuleEdgeRecord(project, from_module, to_module)`
- `ReviewerModuleScoreRecord(project, account_id, module_id, score, updated=None)`

## Test plan
- `test_upsert_module_edge` — round-trip write and read
- `test_delete_module_edges_for_project` — scoped delete
- `test_reviewer_module_scores_sum` — upsert semantics (last write wins) and summing across multiple modules and accounts
- `test_sum_reviewer_scores_empty_modules` — empty input returns `{}`
- `test_delete_reviewer_module_scores_for_project` — scoped delete
- Run `pytest contrib/maintenance/` locally