### PR TITLE
update reviewer diversity and fetch depth in ci config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/java/com/google/gerrit/server/restapi/change/ReviewerRecommender.java
+++ b/java/com/google/gerrit/server/restapi/change/ReviewerRecommender.java
@@ -501,12 +501,14 @@ public class ReviewerRecommender {
     Map<String, Integer> perCluster = new HashMap<>();
     for (Account.Id id : sortedByScore) {
       String cluster = clusterByAccount.get(id);
-      int n = perCluster.getOrDefault(cluster, 0);
-      if (n >= cap) {
-        continue;
+      if (!cluster.equals("_other")) {
+        int n = perCluster.getOrDefault(cluster, 0);
+        if (n >= cap) {
+          continue;
+        }
+        perCluster.put(cluster, n + 1);
       }
       keep.add(id);
-      perCluster.put(cluster, n + 1);
     }
     candidateScores.keySet().removeIf(id -> !keep.contains(id));
     logger.atFine().log("applyDiversityCap: cap=%s kept=%s", cap, keep.size());

--- a/polygerrit-ui/app/elements/change/gr-change-metadata/gr-change-metadata.ts
+++ b/polygerrit-ui/app/elements/change/gr-change-metadata/gr-change-metadata.ts
@@ -26,7 +26,7 @@ import {
   InheritedBooleanInfoConfiguredValue,
   SubmitType,
 } from '../../../constants/constants';
-import { changeIsOpen, isOwner } from '../../../utils/change-util';
+import {changeIsOpen, isOwner} from '../../../utils/change-util';
 import {
   AccountDetailInfo,
   AccountInfo,
@@ -50,10 +50,10 @@ import {
   ServerInfo,
   WebLinkInfo,
 } from '../../../types/common';
-import { assertIsDefined, assertNever, unique } from '../../../utils/common-util';
-import { GrEditableLabel } from '../../shared/gr-editable-label/gr-editable-label';
-import { GrLinkedChip } from '../../shared/gr-linked-chip/gr-linked-chip';
-import { getAppContext } from '../../../services/app-context';
+import {assertIsDefined, assertNever, unique} from '../../../utils/common-util';
+import {GrEditableLabel} from '../../shared/gr-editable-label/gr-editable-label';
+import {GrLinkedChip} from '../../shared/gr-linked-chip/gr-linked-chip';
+import {getAppContext} from '../../../services/app-context';
 import {
   Metadata,
   isSectionSet,
@@ -135,7 +135,7 @@ export class GrChangeMetadata extends LitElement {
   // TODO: Convert to @state. That requires the change model to keep track of
   // current revision actions. Then we can also get rid of the
   // `revision-actions-changed` event.
-  @property({ type: Boolean }) parentIsCurrent?: boolean;
+  @property({type: Boolean}) parentIsCurrent?: boolean;
 
   @state() change?: ParsedChangeInfo;
 
@@ -380,7 +380,7 @@ export class GrChangeMetadata extends LitElement {
       <gr-endpoint-decorator name="change-metadata-item">
         <gr-endpoint-param
           name="labels"
-          .value=${{ ...this.change?.labels }}
+          .value=${{...this.change?.labels}}
         ></gr-endpoint-param>
         <gr-endpoint-param
           name="change"
@@ -468,8 +468,8 @@ export class GrChangeMetadata extends LitElement {
           ></gr-vote-chip>
         </gr-account-chip>
         ${when(
-      this.pushCertificateValidation,
-      () => html`<gr-tooltip-content
+          this.pushCertificateValidation,
+          () => html`<gr-tooltip-content
             has-tooltip
             title=${this.pushCertificateValidation!.message}
           >
@@ -478,7 +478,7 @@ export class GrChangeMetadata extends LitElement {
               class="icon ${this.pushCertificateValidation!.class}"
             ></gr-icon>
           </gr-tooltip-content>`
-    )}
+        )}
       </span>
     </section>`;
   }
@@ -521,20 +521,20 @@ export class GrChangeMetadata extends LitElement {
           ></gr-vote-chip>
         </gr-account-chip>
         ${when(
-      this.editMode &&
-      (role === ChangeRole.AUTHOR || role === ChangeRole.COMMITTER),
-      () => html`
+          this.editMode &&
+            (role === ChangeRole.AUTHOR || role === ChangeRole.COMMITTER),
+          () => html`
             <gr-editable-label
               id="${role}-edit-label"
               placeholder="Update ${name}"
               @changed=${(e: CustomEvent<string>) =>
-          this.handleIdentityChanged(e, role)}
+                this.handleIdentityChanged(e, role)}
               showAsEditPencil
               autocomplete
               .query=${(text: string) => this.getIdentitySuggestions(text)}
             ></gr-editable-label>
           `
-    )}
+        )}
       </span>
     </section>`;
   }
@@ -544,12 +544,18 @@ export class GrChangeMetadata extends LitElement {
     return html`<section class="suggestedReviewers">
       <span class="title">
         Suggested reviewers
-        <br/><label><input type="checkbox" checked /> Use</label>
+        <br /><label><input type="checkbox" checked /> Use</label>
       </span>
       <span class="value">
         <div class="reviewerWeights">
-          <label>Recent history weight: <input type="number" value="1" min="0" max="10"/></label>
-          <label>Contributions weight: <input type="number" value="1" min="0" max="10"/></label>
+          <label
+            >Recent history weight:
+            <input type="number" value="1" min="0" max="10"
+          /></label>
+          <label
+            >Contributions weight:
+            <input type="number" value="1" min="0" max="10"
+          /></label>
         </div>
         ${suggestions.length === 0
           ? html`<span class="noSuggestedReviewers"
@@ -557,7 +563,7 @@ export class GrChangeMetadata extends LitElement {
             >`
           : html`<ul class="suggestedReviewersList">
               ${suggestions.map(
-          suggestion => html`<li class="suggestedReviewersItem">
+                suggestion => html`<li class="suggestedReviewersItem">
                   <gr-button
                     link
                     class="suggestedReviewerName"
@@ -569,7 +575,7 @@ export class GrChangeMetadata extends LitElement {
                     >— suggested reviewer</span
                   >
                 </li>`
-        )}
+              )}
             </ul>`}
       </span>
     </section>`;
@@ -579,12 +585,11 @@ export class GrChangeMetadata extends LitElement {
     if (!this.change) return;
     const changeNum = this.change._number;
     if (!changeNum) return;
-    const suggestions =
-      await this.restApiService.getChangeSuggestedReviewers(
-        changeNum,
-        '',
-        throwingErrorCallback
-      );
+    const suggestions = await this.restApiService.getChangeSuggestedReviewers(
+      changeNum,
+      '',
+      throwingErrorCallback
+    );
     if (suggestions && suggestions.length > 0) {
       this.suggestedReviewers = suggestions
         .slice(0, 3)
@@ -609,7 +614,7 @@ export class GrChangeMetadata extends LitElement {
 
   private handleSuggestedReviewerClick() {
     fire(this, 'show-reply-dialog', {
-      value: { reviewersOnly: true, ccsOnly: false },
+      value: {reviewersOnly: true, ccsOnly: false},
     });
   }
 
@@ -715,7 +720,7 @@ export class GrChangeMetadata extends LitElement {
       <span class="value">
         <ol class=${this.computeParentListClass()}>
           ${this.currentParents.map(
-      parent => html` <li>
+            parent => html` <li>
               <gr-commit-info .commitInfo=${parent}></gr-commit-info>
               <gr-tooltip-content
                 id="parentNotCurrentMessage"
@@ -724,7 +729,7 @@ export class GrChangeMetadata extends LitElement {
                 .title=${this.notCurrentMessage}
               ></gr-tooltip-content>
             </li>`
-    )}
+          )}
         </ol>
       </span>
     </section>`;
@@ -738,9 +743,9 @@ export class GrChangeMetadata extends LitElement {
       <span class="value">
         <gr-commit-info
           .commitInfo=${this.computeMergedCommitInfo(
-      this.change?.current_revision,
-      this.change?.revisions
-    )}
+            this.change?.current_revision,
+            this.change?.revisions
+          )}
         ></gr-commit-info>
       </span>
     </section>`;
@@ -771,19 +776,19 @@ export class GrChangeMetadata extends LitElement {
       <span class="title">Topic</span>
       <span class="value">
         ${when(
-      this.showTopicChip(),
-      () => html` <gr-linked-chip
+          this.showTopicChip(),
+          () => html` <gr-linked-chip
             .text=${this.change?.topic}
             limit="40"
-            href=${createSearchUrl({ topic: this.change!.topic! })}
+            href=${createSearchUrl({topic: this.change!.topic!})}
             ?removable=${!this.topicReadOnly}
             @remove=${this.handleTopicRemoved}
           ></gr-linked-chip>`
-    )}
+        )}
         ${when(
-      this.showAddTopic(),
-      () =>
-        html` <gr-editable-label
+          this.showAddTopic(),
+          () =>
+            html` <gr-editable-label
               class="topicEditableLabel"
               labelText="Set topic"
               .confirmLabel=${'Set Topic'}
@@ -796,7 +801,7 @@ export class GrChangeMetadata extends LitElement {
               autocomplete
               .query=${this.queryTopic}
             ></gr-editable-label>`
-    )}
+        )}
       </span>
     </section>`;
   }
@@ -810,14 +815,14 @@ export class GrChangeMetadata extends LitElement {
       <span class="value">
         <a
           href=${this.computeCherryPickOfUrl(
-      this.change?.cherry_pick_of_change,
-      this.change?.cherry_pick_of_patch_set,
-      this.change?.project
-    )}
+            this.change?.cherry_pick_of_change,
+            this.change?.cherry_pick_of_patch_set,
+            this.change?.project
+          )}
         >
           <gr-limited-text
             text="${this.change?.cherry_pick_of_change},${this.change
-        ?.cherry_pick_of_patch_set}"
+              ?.cherry_pick_of_patch_set}"
             limit="40"
           >
           </gr-limited-text>
@@ -833,10 +838,10 @@ export class GrChangeMetadata extends LitElement {
       <span class="value">
         <a
           href=${createChangeUrl({
-      changeNum: this.change.revert_of,
-      repo: this.change.project,
-      usp: 'metadata',
-    })}
+            changeNum: this.change.revert_of,
+            repo: this.change.project,
+            usp: 'metadata',
+          })}
           >${this.change.revert_of}</a
         >
       </span>
@@ -860,7 +865,7 @@ export class GrChangeMetadata extends LitElement {
       <span class="title">Hashtags</span>
       <span class="value">
         ${(this.change?.hashtags ?? []).map(
-      hashtag => html`<gr-linked-chip
+          hashtag => html`<gr-linked-chip
             class="hashtagChip"
             .text=${hashtag}
             href=${this.computeHashtagUrl(hashtag)}
@@ -869,10 +874,10 @@ export class GrChangeMetadata extends LitElement {
             limit="40"
           >
           </gr-linked-chip>`
-    )}
+        )}
         ${when(
-      !this.hashtagReadOnly,
-      () => html`
+          !this.hashtagReadOnly,
+          () => html`
             <gr-editable-label
               uppercase
               labelText="Add a hashtag"
@@ -884,7 +889,7 @@ export class GrChangeMetadata extends LitElement {
               .query=${this.queryHashtag}
             ></gr-editable-label>
           `
-    )}
+        )}
       </span>
     </section>`;
   }
@@ -1114,7 +1119,7 @@ export class GrChangeMetadata extends LitElement {
         InheritedBooleanInfoConfiguredValue.INHERIT &&
         enableSignedPush.inherited_value) ||
       enableSignedPush.configured_value ===
-      InheritedBooleanInfoConfiguredValue.TRUE
+        InheritedBooleanInfoConfiguredValue.TRUE
     );
   }
 
@@ -1127,18 +1132,18 @@ export class GrChangeMetadata extends LitElement {
   }
 
   private computeShowRepoBranchTogether() {
-    const { project, branch } = this.change!;
+    const {project, branch} = this.change!;
     return !!project && !!branch && project.length + branch.length < 40;
   }
 
   private computeProjectUrl(project?: RepoName) {
     if (!project) return '';
-    return createSearchUrl({ repo: project });
+    return createSearchUrl({repo: project});
   }
 
   private computeBranchUrl(repo?: RepoName, branch?: BranchName) {
     if (!repo || !branch || !this.change || !this.change.status) return '';
-    return createSearchUrl({ branch, repo });
+    return createSearchUrl({branch, repo});
   }
 
   private computeCherryPickOfUrl(
@@ -1158,7 +1163,7 @@ export class GrChangeMetadata extends LitElement {
   }
 
   private computeHashtagUrl(hashtag: Hashtag) {
-    return createSearchUrl({ hashtag, statuses: ['open', 'merged'] });
+    return createSearchUrl({hashtag, statuses: ['open', 'merged']});
   }
 
   private async handleTopicRemoved(e: Event) {
@@ -1220,7 +1225,7 @@ export class GrChangeMetadata extends LitElement {
   // private but used in test
   computeMergedCommitInfo(
     currentrevision?: CommitId,
-    revisions?: { [revisionId: string]: RevisionInfo | EditRevisionInfo }
+    revisions?: {[revisionId: string]: RevisionInfo | EditRevisionInfo}
   ): CommitInfo | undefined {
     if (!currentrevision || !revisions) return;
     const rev = revisions[currentrevision];
@@ -1247,7 +1252,7 @@ export class GrChangeMetadata extends LitElement {
 
   // private but used in test
   computeRevertCommit(): CommitInfo | undefined {
-    const { revertedChange, change } = this;
+    const {revertedChange, change} = this;
     if (revertedChange?.current_revision && revertedChange?.revisions) {
       // TODO(TS): Fix typing
       return {
@@ -1319,7 +1324,7 @@ export class GrChangeMetadata extends LitElement {
 
   // private but used in test
   computeParents(): ParentCommitInfo[] {
-    const { change, revision } = this;
+    const {change, revision} = this;
     if (!revision?.commit) {
       if (!change?.current_revision) return [];
       const newRevision = change.revisions[change.current_revision];
@@ -1364,7 +1369,7 @@ export class GrChangeMetadata extends LitElement {
           .filter(isDefined)
           .filter(unique)
           .map(topic => {
-            return { name: topic, value: topic };
+            return {name: topic, value: topic};
           })
       );
   }
@@ -1384,7 +1389,7 @@ export class GrChangeMetadata extends LitElement {
             inputReg ? inputReg.test(hashtag) : hashtag.includes(input)
           )
           .map(hashtag => {
-            return { name: hashtag, value: hashtag };
+            return {name: hashtag, value: hashtag};
           })
       );
   }
@@ -1402,7 +1407,7 @@ export class GrChangeMetadata extends LitElement {
       account.secondary_emails && emails.push(...account.secondary_emails);
       emails.forEach(email => {
         const identity = name + ' ' + accountEmail(email);
-        identitySuggestions.push({ name: identity });
+        identitySuggestions.push({name: identity});
       });
     });
     return identitySuggestions;

--- a/polygerrit-ui/app/elements/change/gr-reply-dialog/gr-reply-dialog.ts
+++ b/polygerrit-ui/app/elements/change/gr-reply-dialog/gr-reply-dialog.ts
@@ -14,8 +14,8 @@ import '../../shared/gr-account-list/gr-account-list';
 import '../gr-label-scores/gr-label-scores';
 import '../gr-thread-list/gr-thread-list';
 import '../../../styles/shared-styles';
-import { GrReviewerSuggestionsProvider } from '../../../services/gr-reviewer-suggestions-provider/gr-reviewer-suggestions-provider';
-import { getAppContext } from '../../../services/app-context';
+import {GrReviewerSuggestionsProvider} from '../../../services/gr-reviewer-suggestions-provider/gr-reviewer-suggestions-provider';
+import {getAppContext} from '../../../services/app-context';
 import {
   ChangeStatus,
   DraftsAction,
@@ -34,9 +34,9 @@ import {
   removeServiceUsers,
   toReviewInput,
 } from '../../../utils/account-util';
-import { TargetElement } from '../../../api/plugin';
-import { isDefined, ParsedChangeInfo } from '../../../types/types';
-import { GrAccountList } from '../../shared/gr-account-list/gr-account-list';
+import {TargetElement} from '../../../api/plugin';
+import {isDefined, ParsedChangeInfo} from '../../../types/types';
+import {GrAccountList} from '../../shared/gr-account-list/gr-account-list';
 import {
   AccountId,
   AccountInfo,
@@ -58,10 +58,11 @@ import {
   UserId,
   isDraft,
   ChangeViewChangeInfo,
+  GroupName,
 } from '../../../types/common';
-import { GrButton } from '../../shared/gr-button/gr-button';
-import { GrLabelScores } from '../gr-label-scores/gr-label-scores';
-import { GrLabelScoreRow } from '../gr-label-score-row/gr-label-score-row';
+import {GrButton} from '../../shared/gr-button/gr-button';
+import {GrLabelScores} from '../gr-label-scores/gr-label-scores';
+import {GrLabelScoreRow} from '../gr-label-score-row/gr-label-score-row';
 import {
   areSetsEqual,
   assertIsDefined,
@@ -74,13 +75,13 @@ import {
   isPatchsetLevel,
   isUnresolved,
 } from '../../../utils/comment-util';
-import { GrAccountChip } from '../../shared/gr-account-chip/gr-account-chip';
+import {GrAccountChip} from '../../shared/gr-account-chip/gr-account-chip';
 import {
   getApprovalInfo,
   getMaxAccounts,
   StandardLabels,
 } from '../../../utils/label-util';
-import { pluralize } from '../../../utils/string-util';
+import {pluralize} from '../../../utils/string-util';
 import {
   fireAlert,
   fireError,
@@ -98,40 +99,40 @@ import {
   getMentionedReason,
   getReplyByReason,
 } from '../../../utils/attention-set-util';
-import { RestApiService } from '../../../services/gr-rest-api/gr-rest-api';
-import { resolve } from '../../../models/dependency';
-import { changeModelToken } from '../../../models/change/change-model';
-import { LabelNameToValuesMap, PatchSetNumber } from '../../../api/rest-api';
-import { css, html, PropertyValues, LitElement, nothing } from 'lit';
-import { sharedStyles } from '../../../styles/shared-styles';
-import { when } from 'lit/directives/when.js';
-import { classMap } from 'lit/directives/class-map.js';
+import {RestApiService} from '../../../services/gr-rest-api/gr-rest-api';
+import {resolve} from '../../../models/dependency';
+import {changeModelToken} from '../../../models/change/change-model';
+import {LabelNameToValuesMap, PatchSetNumber} from '../../../api/rest-api';
+import {css, html, PropertyValues, LitElement, nothing} from 'lit';
+import {sharedStyles} from '../../../styles/shared-styles';
+import {when} from 'lit/directives/when.js';
+import {classMap} from 'lit/directives/class-map.js';
 import {
   AddReviewerEvent,
   RemoveReviewerEvent,
   ValueChangedEvent,
 } from '../../../types/events';
-import { customElement, property, state, query } from 'lit/decorators.js';
-import { subscribe } from '../../lit/subscription-controller';
-import { configModelToken } from '../../../models/config/config-model';
-import { hasHumanReviewer } from '../../../utils/change-util';
-import { commentsModelToken } from '../../../models/comments/comments-model';
+import {customElement, property, state, query} from 'lit/decorators.js';
+import {subscribe} from '../../lit/subscription-controller';
+import {configModelToken} from '../../../models/config/config-model';
+import {hasHumanReviewer} from '../../../utils/change-util';
+import {commentsModelToken} from '../../../models/comments/comments-model';
 import {
   CommentEditingChangedDetail,
   GrComment,
 } from '../../shared/gr-comment/gr-comment';
-import { ShortcutController } from '../../lit/shortcut-controller';
-import { Key, Modifier, whenVisible } from '../../../utils/dom-util';
-import { GrThreadList } from '../gr-thread-list/gr-thread-list';
-import { userModelToken } from '../../../models/user/user-model';
-import { accountsModelToken } from '../../../models/accounts/accounts-model';
-import { pluginLoaderToken } from '../../shared/gr-js-api-interface/gr-plugin-loader';
-import { modalStyles } from '../../../styles/gr-modal-styles';
-import { ironAnnouncerRequestAvailability } from '../../polymer-util';
-import { GrReviewerUpdatesParser } from '../../shared/gr-rest-api-interface/gr-reviewer-updates-parser';
-import { formStyles } from '../../../styles/form-styles';
-import { navigationToken } from '../../core/gr-navigation/gr-navigation';
-import { getDocUrl } from '../../../utils/url-util';
+import {ShortcutController} from '../../lit/shortcut-controller';
+import {Key, Modifier, whenVisible} from '../../../utils/dom-util';
+import {GrThreadList} from '../gr-thread-list/gr-thread-list';
+import {userModelToken} from '../../../models/user/user-model';
+import {accountsModelToken} from '../../../models/accounts/accounts-model';
+import {pluginLoaderToken} from '../../shared/gr-js-api-interface/gr-plugin-loader';
+import {modalStyles} from '../../../styles/gr-modal-styles';
+import {ironAnnouncerRequestAvailability} from '../../polymer-util';
+import {GrReviewerUpdatesParser} from '../../shared/gr-rest-api-interface/gr-reviewer-updates-parser';
+import {formStyles} from '../../../styles/form-styles';
+import {navigationToken} from '../../core/gr-navigation/gr-navigation';
+import {getDocUrl} from '../../../utils/url-util';
 import {
   readJSONResponsePayload,
   ResponsePayload,
@@ -180,19 +181,19 @@ export class GrReplyDialog extends LitElement {
   private readonly getCommentsModel = resolve(this, commentsModelToken);
 
   // TODO: update type to only ParsedChangeInfo
-  @property({ type: Object })
+  @property({type: Object})
   change?: ParsedChangeInfo | ChangeInfo;
 
-  @property({ type: Boolean })
+  @property({type: Boolean})
   canBeStarted = false;
 
-  @property({ type: Boolean, reflect: true })
+  @property({type: Boolean, reflect: true})
   disabled = false;
 
   @state()
   draftCommentThreads: CommentThread[] = [];
 
-  @property({ type: Object })
+  @property({type: Object})
   permittedLabels?: LabelNameToValuesMap;
 
   @query('#patchsetLevelComment') patchsetLevelGrComment?: GrComment;
@@ -645,13 +646,13 @@ export class GrReplyDialog extends LitElement {
       this.filterReviewerSuggestionGenerator(false);
     this.filterCCSuggestion = this.filterReviewerSuggestionGenerator(true);
 
-    this.shortcuts.addLocal({ key: Key.ESC }, () => this.cancel());
+    this.shortcuts.addLocal({key: Key.ESC}, () => this.cancel());
     this.shortcuts.addLocal(
-      { key: Key.ENTER, modifiers: [Modifier.CTRL_KEY] },
+      {key: Key.ENTER, modifiers: [Modifier.CTRL_KEY]},
       () => this.submit()
     );
     this.shortcuts.addLocal(
-      { key: Key.ENTER, modifiers: [Modifier.META_KEY] },
+      {key: Key.ENTER, modifiers: [Modifier.META_KEY]},
       () => this.submit()
     );
 
@@ -724,9 +725,9 @@ export class GrReplyDialog extends LitElement {
       this,
       () => this.getCommentsModel().draftThreadsSaved$,
       threads =>
-      (this.draftCommentThreads = threads.filter(
-        t => !(isDraft(getFirstComment(t)) && isPatchsetLevel(t))
-      ))
+        (this.draftCommentThreads = threads.filter(
+          t => !(isDraft(getFirstComment(t)) && isPatchsetLevel(t))
+        ))
     );
   }
 
@@ -843,10 +844,10 @@ export class GrReplyDialog extends LitElement {
               .value=${this.change}
             ></gr-endpoint-param>
             ${when(
-      this.attentionExpanded,
-      () => this.renderAttentionDetailsSection(),
-      () => this.renderAttentionSummarySection()
-    )}
+              this.attentionExpanded,
+              () => this.renderAttentionDetailsSection(),
+              () => this.renderAttentionSummarySection()
+            )}
             <gr-endpoint-slot name="above-actions"></gr-endpoint-slot>
             ${this.renderActionsSection()}
           </gr-endpoint-decorator>
@@ -870,12 +871,12 @@ export class GrReplyDialog extends LitElement {
           .filter=${this.filterReviewerSuggestion}
           .pendingConfirmation=${this.reviewerPendingConfirmation}
           @pending-confirmation-changed=${this
-        .handleReviewersConfirmationChanged}
+            .handleReviewersConfirmationChanged}
           .placeholder=${'Add reviewer...'}
           @account-text-changed=${this.handleAccountTextEntry}
           .suggestionsProvider=${this.getReviewerSuggestionsProvider(
-          this.change
-        )}
+            this.change
+          )}
         >
         </gr-account-list>
         <gr-endpoint-slot name="right"></gr-endpoint-slot>
@@ -922,30 +923,26 @@ export class GrReplyDialog extends LitElement {
             />
           </label>
         </div>
-        ${when(
-          this.useSuggestedReviewers,
-          () =>
-            suggestions.length === 0
-              ? html`<span class="noSuggestedReviewers"
-                  >no suggested reviewers</span
-                >`
-              : html`<ul class="suggestedReviewersList">
-                  ${suggestions.map(
-                    s => html`<li class="suggestedReviewersItem">
-                      <gr-button
-                        link
-                        class="suggestedReviewerName"
-                        @click=${() =>
-                          this.handleSuggestedReviewerInlineClick(s.account)}
-                      >
-                        ${s.displayName}
-                      </gr-button>
-                      <span class="suggestedReviewerReason"
-                        >— ${s.reason}</span
-                      >
-                    </li>`
-                  )}
-                </ul>`
+        ${when(this.useSuggestedReviewers, () =>
+          suggestions.length === 0
+            ? html`<span class="noSuggestedReviewers"
+                >no suggested reviewers</span
+              >`
+            : html`<ul class="suggestedReviewersList">
+                ${suggestions.map(
+                  s => html`<li class="suggestedReviewersItem">
+                    <gr-button
+                      link
+                      class="suggestedReviewerName"
+                      @click=${() =>
+                        this.handleSuggestedReviewerInlineClick(s.account)}
+                    >
+                      ${s.displayName}
+                    </gr-button>
+                    <span class="suggestedReviewerReason">— ${s.reason}</span>
+                  </li>`
+                )}
+              </ul>`
         )}
       </div>
     `;
@@ -955,7 +952,6 @@ export class GrReplyDialog extends LitElement {
     if (!(e.target instanceof HTMLInputElement)) return;
     this.useSuggestedReviewers = e.target.checked;
   }
-
 
   private handleRecentHistoryWeightInput(e: Event) {
     this.reviewerRecentHistoryWeight = this.parseWeightInput(e);
@@ -970,7 +966,6 @@ export class GrReplyDialog extends LitElement {
     const parsed = Number(e.target.value);
     if (!Number.isFinite(parsed)) return 1;
     return Math.min(10, Math.max(0, Math.trunc(parsed)));
-
   }
 
   private handleSuggestedReviewerInlineClick(account: AccountInfo) {
@@ -1056,11 +1051,10 @@ export class GrReplyDialog extends LitElement {
       return;
     }
 
-    const suggestions =
-      await this.restApiService.getChangeSuggestedReviewers(
-        this.change._number,
-        ''
-      );
+    const suggestions = await this.restApiService.getChangeSuggestedReviewers(
+      this.change._number,
+      ''
+    );
     if (suggestions && suggestions.length > 0) {
       this.suggestedReviewersInline = suggestions.slice(0, 3).flatMap(s => {
         if (!('account' in s) || !s.account) return [];
@@ -1078,19 +1072,21 @@ export class GrReplyDialog extends LitElement {
     }
 
     const admins = await this.restApiService.getGroupMembers(
-      'Administrators' as any
+      'Administrators' as GroupName
     );
     if (!admins || admins.length === 0) {
       this.suggestedReviewersInline = [];
       return;
     }
 
-    this.suggestedReviewersInline = admins.slice(0, 3).map(account => ({
-      account,
-      displayName:
-        account.name ?? account.email ?? `User ${account._account_id}`,
-      reason: 'suggested reviewer',
-    }));
+    this.suggestedReviewersInline = admins.slice(0, 3).map(account => {
+      return {
+        account,
+        displayName:
+          account.name ?? account.email ?? `User ${account._account_id}`,
+        reason: 'suggested reviewer',
+      };
+    });
   }
 
   private renderLabels() {
@@ -1121,13 +1117,13 @@ export class GrReplyDialog extends LitElement {
         .comment=${this.patchsetLevelComment}
         .comments=${[this.patchsetLevelComment]}
         @comment-unresolved-changed=${(e: ValueChangedEvent<boolean>) => {
-        this.patchsetLevelDraftIsResolved = !e.detail.value;
-      }}
+          this.patchsetLevelDraftIsResolved = !e.detail.value;
+        }}
         @comment-text-changed=${(e: ValueChangedEvent<string>) => {
-        this.patchsetLevelDraftMessage = e.detail.value;
-        // See `addReplyTextChangedCallback` in `ChangeReplyPluginApi`.
-        fire(e.currentTarget as HTMLElement, 'value-changed', e.detail);
-      }}
+          this.patchsetLevelDraftMessage = e.detail.value;
+          // See `addReplyTextChangedCallback` in `ChangeReplyPluginApi`.
+          fire(e.currentTarget as HTMLElement, 'value-changed', e.detail);
+        }}
         .messagePlaceholder=${this.messagePlaceholder}
         hide-header
         permanent-editing-mode
@@ -1140,11 +1136,11 @@ export class GrReplyDialog extends LitElement {
     return html`
       <div
         class=${classMap({
-      patchsetLevelContainer: true,
-      [this.getUnresolvedPatchsetLevelClass(
-        this.patchsetLevelDraftIsResolved
-      )]: true,
-    })}
+          patchsetLevelContainer: true,
+          [this.getUnresolvedPatchsetLevelClass(
+            this.patchsetLevelDraftIsResolved
+          )]: true,
+        })}
       >
         <gr-endpoint-decorator name="reply-text">
           ${this.renderPatchsetLevelComment()}
@@ -1172,12 +1168,12 @@ export class GrReplyDialog extends LitElement {
           >
         </div>
         ${when(
-      this.includeComments,
-      () => html`
+          this.includeComments,
+          () => html`
             <gr-thread-list id="commentList" .threads=${threads} hide-dropdown>
             </gr-thread-list>
           `
-    )}
+        )}
         <span
           id="savingLabel"
           class=${this.computeSavingLabelClass(this.savingComments)}
@@ -1194,15 +1190,15 @@ export class GrReplyDialog extends LitElement {
         <div class="attentionSummary">
           <div>
             ${when(
-      this.computeShowNoAttentionUpdate(),
-      () => html` <span>${this.computeDoNotUpdateMessage()}</span> `
-    )}
+              this.computeShowNoAttentionUpdate(),
+              () => html` <span>${this.computeDoNotUpdateMessage()}</span> `
+            )}
             ${when(
-      !this.computeShowNoAttentionUpdate(),
-      () => html`
+              !this.computeShowNoAttentionUpdate(),
+              () => html`
                 <span>Bring to attention of</span>
                 ${this.computeNewAttentionAccounts().map(
-        account => html`
+                  account => html`
                     <gr-account-label
                       .account=${account}
                       .forceAttention=${this.computeHasNewAttention(account)}
@@ -1212,9 +1208,9 @@ export class GrReplyDialog extends LitElement {
                       @click=${this.handleAttentionClick}
                     ></gr-account-label>
                   `
-      )}
+                )}
               `
-    )}
+            )}
           </div>
           <div>
             ${this.renderModifyAttentionSetButton()}
@@ -1295,8 +1291,8 @@ export class GrReplyDialog extends LitElement {
           </div>
         </div>
         ${when(
-      this.uploader,
-      () => html`
+          this.uploader,
+          () => html`
             <div class="peopleList">
               <div class="peopleListLabel">Uploader</div>
               <div class="peopleListValues">
@@ -1312,12 +1308,12 @@ export class GrReplyDialog extends LitElement {
               </div>
             </div>
           `
-    )}
+        )}
         <div class="peopleList">
           <div class="peopleListLabel">Reviewers</div>
           <div class="peopleListValues">
             ${removeServiceUsers(this.reviewers).map(
-      account => html`
+              account => html`
                 <gr-account-label
                   .account=${account}
                   ?forceAttention=${this.computeHasNewAttention(account)}
@@ -1328,18 +1324,18 @@ export class GrReplyDialog extends LitElement {
                 >
                 </gr-account-label>
               `
-    )}
+            )}
           </div>
         </div>
 
         ${when(
-      this.attentionCcsCount,
-      () => html`
+          this.attentionCcsCount,
+          () => html`
             <div class="peopleList">
               <div class="peopleListLabel">CC</div>
               <div class="peopleListValues">
                 ${removeServiceUsers(this.ccs).map(
-        account => html`
+                  account => html`
                     <gr-account-label
                       .account=${account}
                       ?forceAttention=${this.computeHasNewAttention(account)}
@@ -1350,20 +1346,20 @@ export class GrReplyDialog extends LitElement {
                     >
                     </gr-account-label>
                   `
-      )}
+                )}
               </div>
             </div>
           `
-    )}
+        )}
         ${when(
-      this.computeShowAttentionTip(3),
-      () => html`
+          this.computeShowAttentionTip(3),
+          () => html`
             <div class="attentionTip">
               <gr-icon icon="lightbulb"></gr-icon>
               Please be mindful of requiring attention from too many users.
             </div>
           `
-    )}
+        )}
       </section>
     `;
   }
@@ -1373,22 +1369,22 @@ export class GrReplyDialog extends LitElement {
       <section class="actions">
         <div class="left">
           ${when(
-      this.knownLatestState === LatestPatchState.CHECKING,
-      () => html`
+            this.knownLatestState === LatestPatchState.CHECKING,
+            () => html`
               <span id="checkingStatusLabel">
                 Checking whether patch ${this.latestPatchNum} is latest...
               </span>
             `
-    )}
+          )}
           ${when(
-      this.knownLatestState === LatestPatchState.NOT_LATEST,
-      () => html`
+            this.knownLatestState === LatestPatchState.NOT_LATEST,
+            () => html`
               <span id="notLatestLabel">
                 ${this.computePatchSetWarning()}
                 <gr-button link @click=${this._reload}>Reload</gr-button>
               </span>
             `
-    )}
+          )}
         </div>
         <div class="right">
           <gr-button
@@ -1399,8 +1395,8 @@ export class GrReplyDialog extends LitElement {
             >Cancel</gr-button
           >
           ${when(
-      this.canBeStarted,
-      () => html`
+            this.canBeStarted,
+            () => html`
               <!-- Use 'Send' here as the change may only about reviewers / ccs
             and when this button is visible, the next button will always
             be 'Start review' -->
@@ -1408,20 +1404,20 @@ export class GrReplyDialog extends LitElement {
                 <gr-button
                   link
                   ?disabled=${this.knownLatestState ===
-        LatestPatchState.NOT_LATEST}
+                  LatestPatchState.NOT_LATEST}
                   class="action save"
                   @click=${this.saveClickHandler}
                   >Send As WIP</gr-button
                 >
               </gr-tooltip-content>
             `
-    )}
+          )}
           <gr-tooltip-content
             has-tooltip
             title=${this.computeSendButtonTooltip(
-      this.canBeStarted,
-      this.commentEditing
-    )}
+              this.canBeStarted,
+              this.commentEditing
+            )}
           >
             <gr-button
               id="sendButton"
@@ -1430,8 +1426,8 @@ export class GrReplyDialog extends LitElement {
               class="action send"
               @click=${this.sendClickHandler}
               >${this.canBeStarted
-        ? ButtonLabels.SEND + ' and ' + ButtonLabels.START_REVIEW
-        : ButtonLabels.SEND}
+                ? ButtonLabels.SEND + ' and ' + ButtonLabels.START_REVIEW
+                : ButtonLabels.SEND}
             </gr-button>
           </gr-tooltip-content>
         </div>
@@ -1622,12 +1618,12 @@ export class GrReplyDialog extends LitElement {
           user,
           this.serverConfig
         ) ?? '';
-      reviewInput.add_to_attention_set.push({ user: getUserId(user), reason });
+      reviewInput.add_to_attention_set.push({user: getUserId(user), reason});
     }
     reviewInput.remove_from_attention_set = [];
     for (const user of this.currentAttentionSet) {
       if (!this.newAttentionSet.has(user)) {
-        reviewInput.remove_from_attention_set.push({ user, reason });
+        reviewInput.remove_from_attention_set.push({user, reason});
       }
     }
     this.reportAttentionSetChanges(
@@ -2022,7 +2018,7 @@ export class GrReplyDialog extends LitElement {
       'computeDoNotUpdateMessage',
       new Error(
         'computeDoNotUpdateMessage()' +
-        'should not be called when users were added to the attention set.'
+          'should not be called when users were added to the attention set.'
       )
     );
     return '';
@@ -2363,7 +2359,7 @@ export class GrReplyDialog extends LitElement {
       const role = removedId === ownerId ? 'OWNER' : '_REVIEWER';
       actions.push('REMOVE' + self + role);
     }
-    this.reporting.reportInteraction('attention-set-actions', { actions });
+    this.reporting.reportInteraction('attention-set-actions', {actions});
   }
 }
 

--- a/polygerrit-ui/app/elements/change/gr-reply-dialog/gr-reply-dialog_test.ts
+++ b/polygerrit-ui/app/elements/change/gr-reply-dialog/gr-reply-dialog_test.ts
@@ -24,7 +24,7 @@ import {
   DraftsAction,
   ReviewerState,
 } from '../../../constants/constants';
-import { StandardLabels } from '../../../utils/label-util';
+import {StandardLabels} from '../../../utils/label-util';
 import {
   createAccountWithEmail,
   createAccountWithId,
@@ -36,7 +36,7 @@ import {
   createRevision,
   createServiceUserWithId,
 } from '../../../test/test-data-generators';
-import { GrReplyDialog } from './gr-reply-dialog';
+import {GrReplyDialog} from './gr-reply-dialog';
 import {
   AccountId,
   AccountInfo,
@@ -58,25 +58,25 @@ import {
   UrlEncodedCommentId,
   UserId,
 } from '../../../types/common';
-import { GrAccountList } from '../../shared/gr-account-list/gr-account-list';
-import { GrLabelScoreRow } from '../gr-label-score-row/gr-label-score-row';
-import { GrLabelScores } from '../gr-label-scores/gr-label-scores';
-import { fixture, html, waitUntil, assert } from '@open-wc/testing';
-import { accountKey } from '../../../utils/account-util';
-import { GrButton } from '../../shared/gr-button/gr-button';
-import { GrAccountLabel } from '../../shared/gr-account-label/gr-account-label';
-import { Key, Modifier } from '../../../utils/dom-util';
-import { GrComment } from '../../shared/gr-comment/gr-comment';
-import { testResolver } from '../../../test/common-test-setup';
+import {GrAccountList} from '../../shared/gr-account-list/gr-account-list';
+import {GrLabelScoreRow} from '../gr-label-score-row/gr-label-score-row';
+import {GrLabelScores} from '../gr-label-scores/gr-label-scores';
+import {fixture, html, waitUntil, assert} from '@open-wc/testing';
+import {accountKey} from '../../../utils/account-util';
+import {GrButton} from '../../shared/gr-button/gr-button';
+import {GrAccountLabel} from '../../shared/gr-account-label/gr-account-label';
+import {Key, Modifier} from '../../../utils/dom-util';
+import {GrComment} from '../../shared/gr-comment/gr-comment';
+import {testResolver} from '../../../test/common-test-setup';
 import {
   CommentsModel,
   commentsModelToken,
 } from '../../../models/comments/comments-model';
-import { isOwner } from '../../../utils/change-util';
-import { createNewPatchsetLevel } from '../../../utils/comment-util';
-import { Timing } from '../../../constants/reporting';
-import { ParsedChangeInfo } from '../../../types/types';
-import { changeModelToken } from '../../../models/change/change-model';
+import {isOwner} from '../../../utils/change-util';
+import {createNewPatchsetLevel} from '../../../utils/comment-util';
+import {Timing} from '../../../constants/reporting';
+import {ParsedChangeInfo} from '../../../types/types';
+import {changeModelToken} from '../../../models/change/change-model';
 
 function cloneableResponse(status: number, text: string) {
   return {
@@ -114,7 +114,7 @@ suite('gr-reply-dialog tests', () => {
     };
   };
   const makeGroup = function () {
-    return { id: `${lastId++}` as GroupId };
+    return {id: `${lastId++}` as GroupId};
   };
 
   setup(async () => {
@@ -159,7 +159,7 @@ suite('gr-reply-dialog tests', () => {
     };
     change = {
       ...changeNoRevisions,
-      revisions: { 'commit-id': { ...createRevision(), uploader: owner } },
+      revisions: {'commit-id': {...createRevision(), uploader: owner}},
       current_revision: 'commit-id' as CommitId,
     };
 
@@ -387,9 +387,11 @@ suite('gr-reply-dialog tests', () => {
       suggestedReviewers,
       '.suggestedReviewersTitle input[type="checkbox"]'
     );
-    const [recentWeightInput, contributionsWeightInput] = queryAll<
-      HTMLInputElement
-    >(suggestedReviewers, '.reviewerWeights input[type="number"]');
+    const [recentWeightInput, contributionsWeightInput] =
+      queryAll<HTMLInputElement>(
+        suggestedReviewers,
+        '.reviewerWeights input[type="number"]'
+      );
 
     assert.isTrue(useCheckbox.checked);
     assert.equal(recentWeightInput.value, '1');
@@ -408,9 +410,11 @@ suite('gr-reply-dialog tests', () => {
       element,
       '.suggestedReviewers'
     );
-    const [updatedRecentWeightInput, updatedContributionsWeightInput] = queryAll<
-      HTMLInputElement
-    >(updatedSuggestedReviewers, '.reviewerWeights input[type="number"]');
+    const [updatedRecentWeightInput, updatedContributionsWeightInput] =
+      queryAll<HTMLInputElement>(
+        updatedSuggestedReviewers,
+        '.reviewerWeights input[type="number"]'
+      );
     assert.equal(updatedRecentWeightInput.value, '4');
     assert.equal(updatedContributionsWeightInput.value, '7');
 
@@ -509,10 +513,10 @@ suite('gr-reply-dialog tests', () => {
 
     const account = createAccountWithId(22);
     element.reviewersList!.accounts = [];
-    element.reviewersList!.addAccountItem({ account, count: 1 });
+    element.reviewersList!.addAccountItem({account, count: 1});
     element.reviewersList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account },
+        detail: {account},
       })
     );
     element.requestUpdate();
@@ -634,7 +638,7 @@ suite('gr-reply-dialog tests', () => {
     element.canBeStarted = true;
     await element.updateComplete;
 
-    element.account = { _account_id: 123 as AccountId };
+    element.account = {_account_id: 123 as AccountId};
     element.newAttentionSet = new Set([314 as AccountId]);
     element.uploader = createAccountWithId(314);
     const saveReviewPromise = interceptSaveReview();
@@ -711,28 +715,28 @@ suite('gr-reply-dialog tests', () => {
     hasDraft = true,
     includeComments = true
   ) {
-    element.account = { _account_id: userId };
+    element.account = {_account_id: userId};
     element.reviewers =
       reviewerIds?.map(id => {
-        return { _account_id: id };
+        return {_account_id: id};
       }) ?? [];
     let draftThreads: CommentThread[] = [];
     if (hasDraft) {
       draftThreads = [
         {
-          ...createCommentThread([{ ...createDraft(), unresolved: true }]),
+          ...createCommentThread([{...createDraft(), unresolved: true}]),
         },
       ];
     }
     replyToIds?.forEach(id =>
       draftThreads[0].comments.push({
         ...createComment(),
-        author: { _account_id: id },
+        author: {_account_id: id},
       })
     );
     const change = {
       ...createChange(),
-      owner: { _account_id: ownerId },
+      owner: {_account_id: ownerId},
       status,
       reviewers: {
         [ReviewerState.REVIEWER]: element.reviewers,
@@ -748,7 +752,7 @@ suite('gr-reply-dialog tests', () => {
       change.current_revision = 'b' as CommitId;
       change.revisions = {
         a: createRevision(1),
-        b: { ...createRevision(2), uploader: { _account_id: uploaderId } },
+        b: {...createRevision(2), uploader: {_account_id: uploaderId}},
       };
     }
     element.change = change;
@@ -1155,10 +1159,10 @@ suite('gr-reply-dialog tests', () => {
   });
 
   test('computeNewAttention when adding reviewers', async () => {
-    element.account = { _account_id: 1 as AccountId };
+    element.account = {_account_id: 1 as AccountId};
     element.change = {
       ...createChange(),
-      owner: { _account_id: 5 as AccountId },
+      owner: {_account_id: 5 as AccountId},
       status: ChangeStatus.NEW,
       attention_set: {},
     };
@@ -1166,8 +1170,8 @@ suite('gr-reply-dialog tests', () => {
     await element.updateComplete;
 
     element.reviewers = [
-      { _account_id: 1 as AccountId },
-      { _account_id: 2 as AccountId },
+      {_account_id: 1 as AccountId},
+      {_account_id: 2 as AccountId},
     ];
     element._ccs = [];
     element.draftCommentThreads = [];
@@ -1193,13 +1197,13 @@ suite('gr-reply-dialog tests', () => {
   test('computeNewAttention when sending wip change for review', async () => {
     element.change = {
       ...createChange(),
-      owner: { _account_id: 1 as AccountId },
+      owner: {_account_id: 1 as AccountId},
       status: ChangeStatus.NEW,
       attention_set: {},
       reviewers: {
         [ReviewerState.REVIEWER]: [
-          { ...createAccountWithId(2) },
-          { ...createAccountWithId(3) },
+          {...createAccountWithId(2)},
+          {...createAccountWithId(3)},
         ],
       },
     };
@@ -1207,14 +1211,14 @@ suite('gr-reply-dialog tests', () => {
     await element.updateComplete;
 
     element.reviewers = [
-      { ...createAccountWithId(2) },
-      { ...createAccountWithId(3) },
+      {...createAccountWithId(2)},
+      {...createAccountWithId(3)},
     ];
 
     element._ccs = [];
     element.draftCommentThreads = [];
     element.includeComments = false;
-    element.account = { _account_id: 1 as AccountId };
+    element.account = {_account_id: 1 as AccountId};
 
     await element.updateComplete;
 
@@ -1234,7 +1238,7 @@ suite('gr-reply-dialog tests', () => {
     );
 
     // ... but not when someone else replies.
-    element.account = { _account_id: 4 as AccountId };
+    element.account = {_account_id: 4 as AccountId};
     element.isOwner = isOwner(element.change, element.account);
     element.computeNewAttention();
     assert.sameMembers([...element.newAttentionSet], []);
@@ -1242,10 +1246,10 @@ suite('gr-reply-dialog tests', () => {
 
   test('computeNewAttentionAccounts', () => {
     element.reviewers = [
-      { _account_id: 123 as AccountId, display_name: 'Ernie' },
-      { _account_id: 321 as AccountId, display_name: 'Bert' },
+      {_account_id: 123 as AccountId, display_name: 'Ernie'},
+      {_account_id: 321 as AccountId, display_name: 'Bert'},
     ];
-    element._ccs = [{ _account_id: 7 as AccountId, display_name: 'Elmo' }];
+    element._ccs = [{_account_id: 7 as AccountId, display_name: 'Elmo'}];
     const compute = (currentAtt: AccountId[], newAtt: AccountId[]) => {
       element.currentAttentionSet = new Set(currentAtt);
       element.newAttentionSet = new Set(newAtt);
@@ -1275,9 +1279,9 @@ suite('gr-reply-dialog tests', () => {
       labels: {
         'Code-Review': {
           all: [
-            { _account_id: 1 as AccountId, value: 0 },
-            { _account_id: 2 as AccountId, value: 1 },
-            { _account_id: 3 as AccountId, value: 2 },
+            {_account_id: 1 as AccountId, value: 0},
+            {_account_id: 2 as AccountId, value: 1},
+            {_account_id: 3 as AccountId, value: 2},
           ],
           values: {
             '-2': 'This shall not be submitted',
@@ -1296,14 +1300,14 @@ suite('gr-reply-dialog tests', () => {
           {
             ...createComment(),
             id: '1' as UrlEncodedCommentId,
-            author: { _account_id: 1 as AccountId },
+            author: {_account_id: 1 as AccountId},
             unresolved: false,
           },
           {
             ...createComment(),
             id: '2' as UrlEncodedCommentId,
             in_reply_to: '1' as UrlEncodedCommentId,
-            author: { _account_id: 2 as AccountId },
+            author: {_account_id: 2 as AccountId},
             unresolved: true,
           },
         ]),
@@ -1313,14 +1317,14 @@ suite('gr-reply-dialog tests', () => {
           {
             ...createComment(),
             id: '3' as UrlEncodedCommentId,
-            author: { _account_id: 3 as AccountId },
+            author: {_account_id: 3 as AccountId},
             unresolved: false,
           },
           {
             ...createComment(),
             id: '4' as UrlEncodedCommentId,
             in_reply_to: '3' as UrlEncodedCommentId,
-            author: { _account_id: 4 as AccountId },
+            author: {_account_id: 4 as AccountId},
             unresolved: false,
           },
         ]),
@@ -1340,9 +1344,9 @@ suite('gr-reply-dialog tests', () => {
       labels: {
         'Code-Review': {
           all: [
-            { _account_id: 1 as AccountId, value: 0 },
-            { _account_id: 2 as AccountId, value: 1 },
-            { _account_id: 3 as AccountId, value: 2 },
+            {_account_id: 1 as AccountId, value: 0},
+            {_account_id: 2 as AccountId, value: 1},
+            {_account_id: 3 as AccountId, value: 2},
           ],
           values: {
             '-2': 'This shall not be submitted',
@@ -1360,14 +1364,14 @@ suite('gr-reply-dialog tests', () => {
           {
             ...createComment(),
             id: '1' as UrlEncodedCommentId,
-            author: { _account_id: 1 as AccountId },
+            author: {_account_id: 1 as AccountId},
             unresolved: false,
           },
           {
             ...createComment(),
             id: '2' as UrlEncodedCommentId,
             in_reply_to: '1' as UrlEncodedCommentId,
-            author: { _account_id: 2 as AccountId },
+            author: {_account_id: 2 as AccountId},
             unresolved: true,
           },
         ]),
@@ -1377,7 +1381,7 @@ suite('gr-reply-dialog tests', () => {
           {
             ...createComment(),
             id: '3' as UrlEncodedCommentId,
-            author: { _account_id: 3 as AccountId },
+            author: {_account_id: 3 as AccountId},
             unresolved: false,
           },
           {
@@ -1391,7 +1395,7 @@ suite('gr-reply-dialog tests', () => {
             ...createComment(),
             id: '5' as UrlEncodedCommentId,
             in_reply_to: '4' as UrlEncodedCommentId,
-            author: { _account_id: 4 as AccountId },
+            author: {_account_id: 4 as AccountId},
             unresolved: false,
           },
         ]),
@@ -1509,7 +1513,7 @@ suite('gr-reply-dialog tests', () => {
   });
 
   test('setlabelValue', async () => {
-    element.account = { _account_id: 1 as AccountId };
+    element.account = {_account_id: 1 as AccountId};
     await element.updateComplete;
     const label = 'Verified';
     const value = '+1';
@@ -1689,10 +1693,10 @@ suite('gr-reply-dialog tests', () => {
     test('toast is not fired if change is WIP and becomes active', async () => {
       const account = createAccountWithId(22);
       element.reviewersList!.accounts = [];
-      element.reviewersList!.addAccountItem({ account, count: 1 });
+      element.reviewersList!.addAccountItem({account, count: 1});
       element.reviewersList!.dispatchEvent(
         new CustomEvent('account-added', {
-          detail: { account },
+          detail: {account},
         })
       );
       element.change = {
@@ -1711,10 +1715,10 @@ suite('gr-reply-dialog tests', () => {
     test('toast is fired if change is WIP and becomes active and reviewer added', async () => {
       const account = createAccountWithId(22);
       element.reviewersList!.accounts = [];
-      element.reviewersList!.addAccountItem({ account, count: 1 });
+      element.reviewersList!.addAccountItem({account, count: 1});
       element.reviewersList!.dispatchEvent(
         new CustomEvent('account-added', {
-          detail: { account },
+          detail: {account},
         })
       );
       element.change = {
@@ -1738,7 +1742,7 @@ suite('gr-reply-dialog tests', () => {
       queryAndAssert<GrAccountList>(element, '#reviewers').allowAnyInput
     );
     queryAndAssert(element, '#ccs').dispatchEvent(
-      new CustomEvent('account-text-changed', { bubbles: true, composed: true })
+      new CustomEvent('account-text-changed', {bubbles: true, composed: true})
     );
     assert.isTrue(element.reviewersMutated);
   });
@@ -1756,21 +1760,21 @@ suite('gr-reply-dialog tests', () => {
     element.reviewers = [reviewer1, reviewer2];
     element._ccs = [cc1, cc2];
 
-    assert.isTrue(filter({ account: makeAccount() } as Suggestion));
-    assert.isTrue(filter({ group: makeGroup() } as Suggestion));
+    assert.isTrue(filter({account: makeAccount()} as Suggestion));
+    assert.isTrue(filter({group: makeGroup()} as Suggestion));
 
     // Owner should be excluded.
-    assert.isFalse(filter({ account: owner } as Suggestion));
+    assert.isFalse(filter({account: owner} as Suggestion));
 
     // Existing and pending reviewers should be excluded when isCC = false.
-    assert.isFalse(filter({ account: reviewer1 } as Suggestion));
-    assert.isFalse(filter({ group: reviewer2 } as Suggestion));
+    assert.isFalse(filter({account: reviewer1} as Suggestion));
+    assert.isFalse(filter({group: reviewer2} as Suggestion));
 
     filter = element.filterReviewerSuggestionGenerator(true);
 
     // Existing and pending CCs should be excluded when isCC = true;.
-    assert.isFalse(filter({ account: cc1 } as Suggestion));
-    assert.isFalse(filter({ group: cc2 } as Suggestion));
+    assert.isFalse(filter({account: cc1} as Suggestion));
+    assert.isFalse(filter({group: cc2} as Suggestion));
   });
 
   test('focusOn', async () => {
@@ -1890,7 +1894,7 @@ suite('gr-reply-dialog tests', () => {
 
     element.reviewersList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account: cc1 },
+        detail: {account: cc1},
       })
     );
     await element.updateComplete;
@@ -1898,18 +1902,18 @@ suite('gr-reply-dialog tests', () => {
     assert.deepEqual(element.reviewers, [reviewer1, reviewer2, reviewer3, cc1]);
     assert.deepEqual(element.ccs, [cc2, cc3, cc4]);
 
-    element.reviewersList!.addAccountItem({ account: cc4, count: 1 });
+    element.reviewersList!.addAccountItem({account: cc4, count: 1});
     element.reviewersList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account: cc4 },
+        detail: {account: cc4},
       })
     );
     await element.updateComplete;
 
-    element.reviewersList!.addAccountItem({ account: cc3, count: 1 });
+    element.reviewersList!.addAccountItem({account: cc3, count: 1});
     element.reviewersList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account: cc3 },
+        detail: {account: cc3},
       })
     );
     await element.updateComplete;
@@ -1995,7 +1999,7 @@ suite('gr-reply-dialog tests', () => {
     element._ccs.push(reviewer1);
     element.ccsList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account: reviewer1 },
+        detail: {account: reviewer1},
       })
     );
 
@@ -2007,18 +2011,18 @@ suite('gr-reply-dialog tests', () => {
     assert.deepEqual(element.reviewers, [reviewer2, reviewer3]);
     assert.deepEqual(element.ccs, [cc1, cc2, cc3, cc4, reviewer1]);
 
-    element.ccsList!.addAccountItem({ account: reviewer3, count: 1 });
+    element.ccsList!.addAccountItem({account: reviewer3, count: 1});
     element.ccsList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account: reviewer3 },
+        detail: {account: reviewer3},
       })
     );
     await element.updateComplete;
 
-    element.ccsList!.addAccountItem({ account: reviewer2, count: 1 });
+    element.ccsList!.addAccountItem({account: reviewer2, count: 1});
     element.ccsList!.dispatchEvent(
       new CustomEvent('account-added', {
-        detail: { account: reviewer2 },
+        detail: {account: reviewer2},
       })
     );
     await element.updateComplete;
@@ -2048,7 +2052,7 @@ suite('gr-reply-dialog tests', () => {
 
     element.change!.reviewers = {
       [ReviewerState.CC]: [],
-      [ReviewerState.REVIEWER]: [{ _account_id: 33 as AccountId }],
+      [ReviewerState.REVIEWER]: [{_account_id: 33 as AccountId}],
     };
     await element.updateComplete;
 
@@ -2063,7 +2067,7 @@ suite('gr-reply-dialog tests', () => {
     // Remove and add to other field.
     reviewers.dispatchEvent(
       new CustomEvent('remove-account', {
-        detail: { account: reviewer1 },
+        detail: {account: reviewer1},
         composed: true,
         bubbles: true,
       })
@@ -2073,28 +2077,28 @@ suite('gr-reply-dialog tests', () => {
     assert.isTrue(element.reviewersMutated);
     ccs.entry!.dispatchEvent(
       new CustomEvent('add', {
-        detail: { value: { account: reviewer1 } },
+        detail: {value: {account: reviewer1}},
         composed: true,
         bubbles: true,
       })
     );
     ccs.dispatchEvent(
       new CustomEvent('remove-account', {
-        detail: { account: cc1 },
+        detail: {account: cc1},
         composed: true,
         bubbles: true,
       })
     );
     ccs.dispatchEvent(
       new CustomEvent('remove-account', {
-        detail: { account: cc3 },
+        detail: {account: cc3},
         composed: true,
         bubbles: true,
       })
     );
     reviewers.entry!.dispatchEvent(
       new CustomEvent('add', {
-        detail: { value: { account: cc1 } },
+        detail: {value: {account: cc1}},
         composed: true,
         bubbles: true,
       })
@@ -2112,7 +2116,7 @@ suite('gr-reply-dialog tests', () => {
     // Add to Reviewer/CC which will automatically remove from CC/Reviewer.
     reviewers.entry!.dispatchEvent(
       new CustomEvent('add', {
-        detail: { value: { account: cc2 } },
+        detail: {value: {account: cc2}},
         composed: true,
         bubbles: true,
       })
@@ -2131,7 +2135,7 @@ suite('gr-reply-dialog tests', () => {
 
     ccs.entry!.dispatchEvent(
       new CustomEvent('add', {
-        detail: { value: { account: reviewer2 } },
+        detail: {value: {account: reviewer2}},
         composed: true,
         bubbles: true,
       })
@@ -2188,7 +2192,7 @@ suite('gr-reply-dialog tests', () => {
 
     element.change!.reviewers = {
       [ReviewerState.CC]: [],
-      [ReviewerState.REVIEWER]: [{ _account_id: reviewer1._account_id }],
+      [ReviewerState.REVIEWER]: [{_account_id: reviewer1._account_id}],
     };
 
     await element.updateComplete;
@@ -2202,14 +2206,14 @@ suite('gr-reply-dialog tests', () => {
     // Remove and add to other field.
     reviewers.dispatchEvent(
       new CustomEvent('remove', {
-        detail: { account: reviewer1 },
+        detail: {account: reviewer1},
         composed: true,
         bubbles: true,
       })
     );
     ccs.entry!.dispatchEvent(
       new CustomEvent('add', {
-        detail: { value: { account: reviewer1 } },
+        detail: {value: {account: reviewer1}},
         composed: true,
         bubbles: true,
       })
@@ -2233,7 +2237,7 @@ suite('gr-reply-dialog tests', () => {
 
     element.change!.reviewers = {
       [ReviewerState.CC]: [],
-      [ReviewerState.REVIEWER]: [{ _account_id: reviewer1._account_id }],
+      [ReviewerState.REVIEWER]: [{_account_id: reviewer1._account_id}],
     };
 
     await element.updateComplete;
@@ -2367,7 +2371,7 @@ suite('gr-reply-dialog tests', () => {
 
   test('buttons disabled until all API calls are resolved', () => {
     stubSaveReview(() => {
-      return { ready: true };
+      return {ready: true};
     });
     return element.send(true, true).then(() => {
       assert.isFalse(element.disabled);
@@ -2456,7 +2460,7 @@ suite('gr-reply-dialog tests', () => {
   test('isSendDisabled_draftCommentsSend', () => {
     // Mock nonempty comment draft array; with sending comments.
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = '';
     element.reviewersMutated = false;
     element.labelsChanged = false;
@@ -2470,7 +2474,7 @@ suite('gr-reply-dialog tests', () => {
   test('isSendDisabled_draftCommentsDoNotSend', () => {
     // Mock nonempty comment draft array; without sending comments.
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = '';
     element.reviewersMutated = false;
     element.labelsChanged = false;
@@ -2485,7 +2489,7 @@ suite('gr-reply-dialog tests', () => {
   test('isSendDisabled_changeMessage', () => {
     // Mock nonempty change message.
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = 'test';
     element.reviewersMutated = false;
     element.labelsChanged = false;
@@ -2500,7 +2504,7 @@ suite('gr-reply-dialog tests', () => {
   test('isSendDisabledreviewersChanged', () => {
     // Mock reviewers mutated.
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = '';
     element.reviewersMutated = true;
     element.labelsChanged = false;
@@ -2515,7 +2519,7 @@ suite('gr-reply-dialog tests', () => {
   test('isSendDisabled_labelsChanged', () => {
     // Mock labels changed.
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = '';
     element.reviewersMutated = false;
     element.labelsChanged = true;
@@ -2530,7 +2534,7 @@ suite('gr-reply-dialog tests', () => {
   test('isSendDisabled_dialogDisabled', () => {
     // Whole dialog is disabled.
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = '';
     element.reviewersMutated = false;
     element.labelsChanged = true;
@@ -2548,7 +2552,7 @@ suite('gr-reply-dialog tests', () => {
       element.change!.labels![StandardLabels.CODE_REVIEW]! as DetailedLabelInfo
     ).all = [account];
     element.canBeStarted = false;
-    element.draftCommentThreads = [{ ...createCommentThread([createComment()]) }];
+    element.draftCommentThreads = [{...createCommentThread([createComment()])}];
     element.patchsetLevelDraftMessage = '';
     element.reviewersMutated = false;
     element.labelsChanged = false;
@@ -2756,7 +2760,7 @@ suite('gr-reply-dialog tests', () => {
     });
 
     test('replies to patchset level comments are not filtered out', async () => {
-      const draft = { ...createDraft(), in_reply_to: '1' as UrlEncodedCommentId };
+      const draft = {...createDraft(), in_reply_to: '1' as UrlEncodedCommentId};
       commentsModel.setState({
         drafts: {
           'abc.txt': [draft],
@@ -2833,7 +2837,7 @@ suite('gr-reply-dialog tests', () => {
     const changeStateUpdateSpy = sinon.spy(changeModel, 'updateStateChange');
     const responseChange = {
       ...change,
-      labels: { Verified: createLabelInfo(-1) },
+      labels: {Verified: createLabelInfo(-1)},
       revisions: undefined,
       current_revision: undefined,
       current_revision_number: (change.current_revision_number +
@@ -2866,7 +2870,7 @@ suite('gr-reply-dialog tests', () => {
     assert.isTrue(reloadTriggered);
 
     // All revision information is old, but all other information is new.
-    const expectedChange = { ...change, labels: { Verified: createLabelInfo(-1) } };
+    const expectedChange = {...change, labels: {Verified: createLabelInfo(-1)}};
     assert.deepEqual(changeStateUpdateSpy.firstCall.args[0], expectedChange);
   });
 
@@ -2878,7 +2882,7 @@ suite('gr-reply-dialog tests', () => {
     const changeStateUpdateSpy = sinon.spy(changeModel, 'updateStateChange');
     const responseChange = {
       ...change,
-      labels: { Verified: createLabelInfo(-1) },
+      labels: {Verified: createLabelInfo(-1)},
       revisions: undefined,
       current_revision: undefined,
       current_revision_number: change.current_revision_number,
@@ -2907,7 +2911,7 @@ suite('gr-reply-dialog tests', () => {
     await waitEventLoop();
     assert.isFalse(reloadTriggered);
     // All revision information is old, but all other information is new.
-    const expectedChange = { ...change, labels: { Verified: createLabelInfo(-1) } };
+    const expectedChange = {...change, labels: {Verified: createLabelInfo(-1)}};
     assert.deepEqual(changeStateUpdateSpy.firstCall.args[0], expectedChange);
   });
 


### PR DESCRIPTION
Tests were failing because the reviewer diversity cap limited diversity for all clusers, including the fallback. This updates the logic to give fallbacks unlimited diversity to maximize valid suggestions.

Further, the CI config now fetches the full history so that `git describe` produces a valid version.